### PR TITLE
remove --exec flag from a few more spots

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -41,10 +41,10 @@ jobs:
             # kurtosis run github.com/kurtosis-tech/sei-package@ee5314d1be9ef2af29715017bbea82ed87c142a3 '{"cluster_size": 4, "num_accounts": 10, "image": "sei-chain/localnode", "git_ref": "${{ github.head_ref}}"}' --enclave sei-integration-test
       
       - name: Verify Sei Chain is able to start up
-        run: kurtosis service shell sei-integration-test sei-node-0 --exec /sei-protocol/sei-chain/integration_test/startup/startup_test.sh
+        run: kurtosis service exec sei-integration-test sei-node-0 /sei-protocol/sei-chain/integration_test/startup/startup_test.sh
 
       - name: Testing Dex Module
-        run: kurtosis service shell sei-integration-test sei-node-0 --exec /sei-protocol/sei-chain/integration_test/dex_module/place_order_test.sh
+        run: kurtosis service exec sei-integration-test sei-node-0 /sei-protocol/sei-chain/integration_test/dex_module/place_order_test.sh
 
       - name: Testing Wasm Module
         run: |


### PR DESCRIPTION
the `--exec` flag on the `kurtosis service shell` command is now deprecated in favor of a easier to use `kurtosis service exec` command. 

I found a few more spots where we're still using the `--exec` flag so this PR replaces those `--exec` flags with the `kurtosis service exec` command. 